### PR TITLE
Handle empty control message

### DIFF
--- a/src/dissolve/mdns/transport/ipv6.go
+++ b/src/dissolve/mdns/transport/ipv6.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/jmalloc/twelf/src/twelf"
@@ -71,6 +72,13 @@ func (t *IPv6Transport) Read() (*InboundPacket, error) {
 	n, cm, src, err := t.pc.ReadFrom(buf)
 	if err != nil {
 		putBuffer(buf)
+		logReadError(t.Logger, t.Group(), err)
+		return nil, err
+	}
+
+	if cm == nil {
+		putBuffer(buf)
+		err := fmt.Errorf("empty control message from %s", t.Group())
 		logReadError(t.Logger, t.Group(), err)
 		return nil, err
 	}

--- a/src/dissolve/mdns/transport/ipv6.go
+++ b/src/dissolve/mdns/transport/ipv6.go
@@ -78,7 +78,7 @@ func (t *IPv6Transport) Read() (*InboundPacket, error) {
 
 	if cm == nil {
 		putBuffer(buf)
-		err := fmt.Errorf("empty control message from %s", t.Group())
+		err := fmt.Errorf("empty control message from %s", src)
 		logReadError(t.Logger, t.Group(), err)
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds logic to check and handle an empty control
message in dissolve.mdns.transport.IPv6Transport.Read() method.